### PR TITLE
timeframe select for charts

### DIFF
--- a/src-tauri/migrations/seed/20260105120000_dev_seed_data.sql
+++ b/src-tauri/migrations/seed/20260105120000_dev_seed_data.sql
@@ -45,11 +45,13 @@ WITH RECURSIVE
     )
 
 SELECT 
-    -- START TIME: Date + Random Hour (08:00 to 22:00) + Random Minute
-    datetime(d.dt, '+' || (8 + abs(random()) % 14) || ' hours', '+' || (abs(random()) % 60) || ' minutes') as start_time,
+    -- START TIME: Date + Slot-based Hour (2h spacing) + Random Minute (0-15)
+    -- Slots: 08:xx, 10:xx, 12:xx, 14:xx, 16:xx, 18:xx, 20:xx, 22:xx
+    datetime(d.dt, '+' || (8 + (s.i - 1) * 2) || ' hours', '+' || (abs(random()) % 15) || ' minutes') as start_time,
     
-    -- DURATION: 15 to 120 mins (in seconds)
-    ((abs(random()) % 106) + 15) * 60 as duration,
+    -- DURATION: 25 to 90 mins (in seconds)
+    -- Max logic: Start 00:15 + 90m = 01:45. Next slot starts at 02:00. Guaranteed 15m gap.
+    ((abs(random()) % 66) + 25) * 60 as duration,
     
     -- FINISHED: 85% chance true
     CASE WHEN (abs(random()) % 100) < 85 THEN 1 ELSE 0 END as finished,

--- a/src/components/stats/ProductivityTimeOfDay.vue
+++ b/src/components/stats/ProductivityTimeOfDay.vue
@@ -1,7 +1,9 @@
 <script setup lang="ts">
-import { computed } from "vue";
+import { computed, ref } from "vue";
 import { useTheme } from "vuetify";
 import type { Session } from "../../funcs/commands";
+import { fromUTCString, isToday } from "../../funcs/stats/date_handling";
+import { calculateHourlyDistribution } from "../../funcs/stats/productivity";
 
 const props = defineProps<{
 	sessions: Session[];
@@ -9,15 +11,44 @@ const props = defineProps<{
 
 const theme = useTheme();
 
-const series = computed(() => {
-	const hours = new Array(24).fill(0);
-	props.sessions.forEach((s) => {
-		if (!s.start_time || !s.duration) return;
-		const hour = new Date(s.start_time).getHours();
-		hours[hour] += s.duration / 60; // Convert to minutes
-	});
+type Timeframe = "1D" | "1M" | "1Y" | "YTD";
+const timeframes: Timeframe[] = ["1D", "1M", "1Y", "YTD"];
+const selectedTimeframe = ref<Timeframe>("1D");
 
-	return hours.map((h) => Math.round(h));
+const filteredSessions = computed(() => {
+	const now = new Date();
+	const sessions = props.sessions.filter((s) => s.start_time && s.duration);
+
+	switch (selectedTimeframe.value) {
+		case "1D":
+			return sessions.filter((s) => isToday(fromUTCString(s.start_time)));
+		case "1M": {
+			const cutoff = new Date(now);
+			cutoff.setDate(now.getDate() - 30);
+			return sessions.filter(
+				(s) => s.start_time && fromUTCString(s.start_time) >= cutoff
+			);
+		}
+		case "1Y": {
+			const cutoff = new Date(now);
+			cutoff.setDate(now.getDate() - 365);
+			return sessions.filter(
+				(s) => s.start_time && fromUTCString(s.start_time) >= cutoff
+			);
+		}
+		case "YTD": {
+			const startOfYear = new Date(now.getFullYear(), 0, 1);
+			return sessions.filter(
+				(s) => s.start_time && fromUTCString(s.start_time) >= startOfYear
+			);
+		}
+	}
+});
+
+const series = computed(() => {
+	// If 1D, force total (divisor 1)
+	const isDayView = selectedTimeframe.value === "1D";
+	return calculateHourlyDistribution(filteredSessions.value, isDayView);
 });
 
 const chartOptions = computed(() => {
@@ -77,7 +108,11 @@ const chartOptions = computed(() => {
 		tooltip: {
 			theme: isDark ? "dark" : "light",
 			y: {
-				formatter: (val: number) => `${val} mins`
+				formatter: (val: number) => {
+					// Format based on timeframe
+					if (selectedTimeframe.value === "1D") return `${val} mins`;
+					return `${val} mins/day avg`;
+				}
 			}
 		},
 		colors: ["#00897B"]
@@ -87,7 +122,24 @@ const chartOptions = computed(() => {
 
 <template>
 	<div class="bg-light-surface dark:bg-dark-surface rounded-xl p-4 border border-light-border dark:border-dark-border">
-		<h3 class="text-lg font-semibold text-lightText-primary dark:text-white mb-4">Productivity by Time of Day</h3>
+		<div class="flex items-center justify-between mb-4">
+			<h3 class="text-lg font-semibold text-lightText-primary dark:text-white">Productivity by Time of Day</h3>
+			
+			<div class="flex bg-light-bg dark:bg-dark-bg rounded-lg p-1 gap-1">
+				<button
+					v-for="tf in timeframes"
+					:key="tf"
+					@click="selectedTimeframe = tf"
+					class="px-2 py-0.5 text-xs font-medium rounded transition-colors"
+					:class="selectedTimeframe === tf 
+						? 'bg-light-surface dark:bg-dark-surface text-pomodo-orange shadow-sm' 
+						: 'text-lightText-muted dark:text-text-muted hover:text-lightText-primary dark:hover:text-white'"
+				>
+					{{ tf }}
+				</button>
+			</div>
+		</div>
+		
 		<apexchart
 			type="polarArea"
 			height="350"

--- a/src/components/stats/ProjectDistribution.vue
+++ b/src/components/stats/ProjectDistribution.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
-import { computed, onMounted } from "vue";
+import { computed, onMounted, ref } from "vue";
 import { useTheme } from "vuetify";
 import type { Session } from "../../funcs/commands";
+import { fromUTCString, isToday } from "../../funcs/stats/date_handling";
 import { useCategoryStore } from "../../stores/categories";
 import { useProjectStore } from "../../stores/project";
 
@@ -13,17 +14,51 @@ const theme = useTheme();
 const categoryStore = useCategoryStore();
 const projectStore = useProjectStore();
 
+type Timeframe = "1D" | "1M" | "1Y" | "YTD";
+const timeframes: Timeframe[] = ["1D", "1M", "1Y", "YTD"];
+const selectedTimeframe = ref<Timeframe>("1D");
+
 onMounted(() => {
 	if (categoryStore.categories.length === 0) categoryStore.fetchCategories();
 	if (projectStore.projects.length === 0) projectStore.fetchProjects();
 });
 
+const filteredSessions = computed(() => {
+	const now = new Date();
+	const sessions = props.sessions.filter((s) => s.duration);
+
+	switch (selectedTimeframe.value) {
+		case "1D":
+			return sessions.filter(
+				(s) => s.start_time && isToday(fromUTCString(s.start_time))
+			);
+		case "1M": {
+			const cutoff = new Date(now);
+			cutoff.setDate(now.getDate() - 30);
+			return sessions.filter(
+				(s) => s.start_time && fromUTCString(s.start_time) >= cutoff
+			);
+		}
+		case "1Y": {
+			const cutoff = new Date(now);
+			cutoff.setDate(now.getDate() - 365);
+			return sessions.filter(
+				(s) => s.start_time && fromUTCString(s.start_time) >= cutoff
+			);
+		}
+		case "YTD": {
+			const startOfYear = new Date(now.getFullYear(), 0, 1);
+			return sessions.filter(
+				(s) => s.start_time && fromUTCString(s.start_time) >= startOfYear
+			);
+		}
+	}
+});
+
 const projectStats = computed(() => {
 	const map = new Map<string, number>();
 
-	props.sessions.forEach((s) => {
-		if (!s.duration) return;
-
+	filteredSessions.value.forEach((s) => {
 		let name = "Uncategorized";
 		if (s.project_id) {
 			const project = projectStore.projects.find((p) => p.id === s.project_id);
@@ -35,7 +70,7 @@ const projectStats = computed(() => {
 			name = category ? category.name : `Category #${s.category_id}`;
 		}
 
-		map.set(name, (map.get(name) || 0) + s.duration);
+		map.set(name, (map.get(name) || 0) + (s.duration || 0));
 	});
 
 	return Array.from(map.entries())
@@ -74,7 +109,16 @@ const chartOptions = computed(() => {
 		tooltip: {
 			theme: isDark ? "dark" : "light",
 			y: {
-				formatter: (val: number) => `${Math.round(val / 60)} mins`
+				formatter: (val: number) => {
+					// Format minutes/hours based on magnitude
+					const mins = Math.round(val / 60);
+					if (mins >= 60) {
+						const h = Math.floor(mins / 60);
+						const m = mins % 60;
+						return m > 0 ? `${h}h ${m}m` : `${h}h`;
+					}
+					return `${mins} mins`;
+				}
 			}
 		},
 		// Pomodo Palette
@@ -85,7 +129,24 @@ const chartOptions = computed(() => {
 
 <template>
 	<div class="bg-light-surface dark:bg-dark-surface rounded-xl p-4 border border-light-border dark:border-dark-border">
-		<h3 class="text-lg font-semibold text-lightText-primary dark:text-white mb-4">Distribution by Category</h3>
+		<div class="flex items-center justify-between mb-4">
+			<h3 class="text-lg font-semibold text-lightText-primary dark:text-white">Distribution by Category</h3>
+			
+			<div class="flex bg-light-bg dark:bg-dark-bg rounded-lg p-1 gap-1">
+				<button
+					v-for="tf in timeframes"
+					:key="tf"
+					@click="selectedTimeframe = tf"
+					class="px-2 py-0.5 text-xs font-medium rounded transition-colors"
+					:class="selectedTimeframe === tf 
+						? 'bg-light-surface dark:bg-dark-surface text-pomodo-orange shadow-sm' 
+						: 'text-lightText-muted dark:text-text-muted hover:text-lightText-primary dark:hover:text-white'"
+				>
+					{{ tf }}
+				</button>
+			</div>
+		</div>
+
 		<apexchart
 			type="donut"
 			height="250"

--- a/src/components/stats/WeeklyFocusChart.vue
+++ b/src/components/stats/WeeklyFocusChart.vue
@@ -1,34 +1,80 @@
 <script setup lang="ts">
 import { computed, onMounted, onUnmounted, ref } from "vue";
 import type { Session } from "../../funcs/commands";
+import { fromUTCString, isToday } from "../../funcs/stats/date_handling";
 
 // 2. Receive data from parent
 const props = defineProps<{
 	data: Session[];
 }>();
 
-// 3. Internal Logic: Transform raw sessions into Chart Bars
+// 3. Timeframe Logic
+type Timeframe = "1D" | "1M" | "1Y" | "YTD";
+const timeframes: Timeframe[] = ["1D", "1M", "1Y", "YTD"];
+const selectedTimeframe = ref<Timeframe>("1D");
+
+const filteredSessions = computed(() => {
+	const now = new Date();
+	const list = props.data || [];
+
+	switch (selectedTimeframe.value) {
+		case "1D": // Current Week (or just Today?) -> logic below implies averaging over timeframe.
+			// For "1D" in this context (Weekly Chart), users might expect "This Week" or "Last 24h"?
+			// But matching ProductivityTimeOfDay "1D" means "Today".
+			// If we filter to "Today", the chart will show only the current day's bar.
+			return list.filter((s) => isToday(fromUTCString(s.start_time)));
+		case "1M": {
+			const cutoff = new Date(now);
+			cutoff.setDate(now.getDate() - 30);
+			return list.filter((s) => fromUTCString(s.start_time) >= cutoff);
+		}
+		case "1Y": {
+			const cutoff = new Date(now);
+			cutoff.setDate(now.getDate() - 365);
+			return list.filter((s) => fromUTCString(s.start_time) >= cutoff);
+		}
+		case "YTD": {
+			const startOfYear = new Date(now.getFullYear(), 0, 1);
+			return list.filter((s) => fromUTCString(s.start_time) >= startOfYear);
+		}
+	}
+});
+
+// 4. Transform raw sessions into Chart Bars
 const chartData = computed(() => {
 	const days = ["M", "T", "W", "T", "F", "S", "S"];
 	const dailyTotals = new Array(7).fill(0);
+	const uniqueWeeks = new Set<string>();
 
 	// Aggregate
-	const list = props.data || [];
-	list.forEach((s) => {
+	filteredSessions.value.forEach((s) => {
 		if (s.finished && s.start_time) {
-			const d = new Date(s.start_time);
+			const d = fromUTCString(s.start_time);
 			// Convert Sunday(0)-Saturday(6) to Monday(0)-Sunday(6)
 			const dayIndex = (d.getDay() + 6) % 7;
 			dailyTotals[dayIndex] += s.duration;
+
+			// Track Unique Weeks for divisor (using Monday of that week as key)
+			const monday = new Date(d);
+			monday.setDate(d.getDate() - dayIndex);
+			monday.setHours(0, 0, 0, 0);
+			uniqueWeeks.add(monday.toDateString());
 		}
 	});
 
+	// Divisor Logic
+	// If 1D, we show totals (Divisor 1).
+	// If longer timeframe, we show Average Weekly Profile (divide by count of active weeks).
+	const divisor =
+		selectedTimeframe.value === "1D" ? 1 : Math.max(1, uniqueWeeks.size);
+
 	// Scale
-	const maxDuration = Math.max(...dailyTotals, 1); // Prevent divide by zero
+	const values = dailyTotals.map((t) => t / divisor);
+	const maxDuration = Math.max(...values, 1); // Prevent divide by zero
 
 	// Map to View Model
 	return days.map((label, index) => {
-		const seconds = dailyTotals[index];
+		const seconds = values[index];
 		return {
 			label,
 			valueDisplay: (seconds / 3600).toFixed(1),
@@ -38,7 +84,7 @@ const chartData = computed(() => {
 	});
 });
 
-// 3. UI State (Local to this component)
+// 5. UI State (Local to this component)
 const activeDayIndex = ref<number | null>(null);
 const chartContainerRef = ref<HTMLElement | null>(null);
 
@@ -50,7 +96,7 @@ const toggleTooltip = (index: number) => {
 	}
 };
 
-// 4. Click Outside Logic
+// 6. Click Outside Logic
 const handleClickOutside = (event: MouseEvent) => {
 	if (activeDayIndex.value !== null) {
 		if (
@@ -62,7 +108,7 @@ const handleClickOutside = (event: MouseEvent) => {
 	}
 };
 
-// 5. Lifecycle Hooks for Event Listeners
+// 7. Lifecycle Hooks for Event Listeners
 onMounted(() => {
 	document.addEventListener("click", handleClickOutside);
 });
@@ -74,7 +120,23 @@ onUnmounted(() => {
 
 <template>
   <section class="mt-10">
-    <h2 class="text-lg font-semibold text-lightText-primary dark:text-white mb-5">Activity Chart</h2>
+    <div class="flex items-center justify-between mb-5">
+      <h2 class="text-lg font-semibold text-lightText-primary dark:text-white">Activity Chart</h2>
+      
+      <div class="flex bg-light-bg dark:bg-dark-bg rounded-lg p-1 gap-1">
+        <button
+          v-for="tf in timeframes"
+          :key="tf"
+          @click="selectedTimeframe = tf"
+          class="px-2 py-0.5 text-xs font-medium rounded transition-colors"
+          :class="selectedTimeframe === tf 
+            ? 'bg-light-surface dark:bg-dark-surface text-pomodo-orange shadow-sm' 
+            : 'text-lightText-muted dark:text-text-muted hover:text-lightText-primary dark:hover:text-white'"
+        >
+          {{ tf }}
+        </button>
+      </div>
+    </div>
     
     <div 
       ref="chartContainerRef"
@@ -94,6 +156,7 @@ onUnmounted(() => {
           >
             <span class="text-xs text-pomodo-orange font-mono font-bold">
               {{ day.valueDisplay }}h
+              <span v-if="selectedTimeframe !== '1D'" class="text-[0.6rem] font-normal text-lightText-muted dark:text-text-muted">avg</span>
             </span>
             <div class="absolute -bottom-1 left-1/2 -translate-x-1/2 w-2 h-2 bg-light-bg dark:bg-dark-bg border-r border-b border-light-border dark:border-dark-border rotate-45"></div>
           </div>

--- a/src/funcs/stats/__tests__/productivity.spec.ts
+++ b/src/funcs/stats/__tests__/productivity.spec.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from "vitest";
+import type { Session } from "../../commands";
+import { calculateHourlyDistribution } from "../productivity";
+
+describe("calculateHourlyDistribution", () => {
+	it("should return zeros for empty sessions", () => {
+		const result = calculateHourlyDistribution([]);
+		expect(result).toHaveLength(24);
+		expect(result.every((h) => h === 0)).toBe(true);
+	});
+
+	it("should distribute a session fitting in one hour", () => {
+		// 10:15 - 10:45 (30m)
+		const sessions: Partial<Session>[] = [
+			{ start_time: "2024-01-01T10:15:00Z", duration: 30 * 60 }
+		];
+		// Timezone note: The function uses `fromUTCString` which results in local time.
+		// For deterministic tests we assume local time is consistent or we invoke `fromUTCString` to check expected hour.
+		// But wait, the function takes `Session[]` which has `start_time` as string.
+		// `fromUTCString` logic: if ends with Z, treat as UTC.
+
+		// To make this test simpler and robust against test runner timezone,
+		// we can mock `fromUTCString` or construct `start_time` carefully.
+
+		// Let's use a known local date string format for the test input if possible,
+		// but `fromUTCString` expects ISO-like.
+
+		// Better approach: Since `calculateHourlyDistribution` uses `fromUTCString` (which does `new Date(string)`),
+		// we'll rely on the fact that `2024-01-01T10:00:00` (without Z) is treated as local time in many comparisons,
+		// OR we adjust expectations to the local timezone.
+
+		// Wait, `fromUTCString` ensures it ends with Z.
+		// So "2024-01-01T10:15:00" -> "2024-01-01T10:15:00Z" -> UTC time.
+		// Then `startDate.getHours()` gets LOCAL hour.
+		// If I run this in UTC environment, 10Z is 10.
+		// If I run in +2, 10Z is 12.
+
+		// To verify logic independent of timezone, let's construct sessions such that we know the local hour.
+		// But we can't easily control "Local Hour" from `start_time` string without knowing the offset.
+
+		// Workaround: We can check if the logic *distributes* correctly relative to the *start hour*.
+		// But the array is fixed 0-23.
+
+		// Let's just create a date object, get its local ISO string, and use that.
+		// Actually, `fromUTCString` forces `Z` at the end if missing.
+
+		// Let's assume the test runner is in a specific timezone or we accept whatever hour it lands in.
+		// We'll calculate expected hour dynamically.
+		const date = new Date("2024-01-01T10:15:00Z");
+		const localHour = date.getHours(); // e.g. 12 if +2
+
+		const result = calculateHourlyDistribution(sessions as Session[], true);
+
+		expect(result[localHour]).toBe(30);
+		expect(result[(localHour + 1) % 24]).toBe(0);
+	});
+
+	it("should split session spanning two hours (User Case: 08:30 + 45m)", () => {
+		// 08:30 UTC + 45m -> 08:30 to 09:15 UTC
+		// Logic: 30m in 08, 15m in 09 (in UTC terms).
+		// In local time, it shifts but relative split is same.
+
+		const start = "2024-01-01T08:30:00Z";
+		const sessions: Partial<Session>[] = [
+			{ start_time: start, duration: 45 * 60 }
+		];
+
+		const date = new Date(start);
+		const h1 = date.getHours();
+		const h2 = (h1 + 1) % 24;
+
+		const result = calculateHourlyDistribution(sessions as Session[], true);
+
+		expect(result[h1]).toBe(30);
+		expect(result[h2]).toBe(15);
+	});
+
+	it("should handle session spanning midnight", () => {
+		// 23:30 UTC + 60m -> 23:30 to 00:30 UTC
+		const start = "2024-01-01T23:30:00Z";
+		const sessions: Partial<Session>[] = [
+			{ start_time: start, duration: 60 * 60 }
+		];
+
+		const date = new Date(start);
+		const h1 = date.getHours();
+		const h2 = (h1 + 1) % 24;
+
+		const result = calculateHourlyDistribution(sessions as Session[], true);
+
+		expect(result[h1]).toBe(30);
+		expect(result[h2]).toBe(30);
+	});
+
+	it("should handle active days divisor", () => {
+		// 1 day with 60 mins -> 60 avg
+		// 2 days, each with 60 mins -> 60 avg (120 total / 2)
+		// 2 days, one 60m, one 30m -> 45 avg
+
+		const s1 = "2024-01-01T10:00:00Z";
+		const s2 = "2024-01-02T10:00:00Z"; // Different day
+
+		const sessions: Partial<Session>[] = [
+			{ start_time: s1, duration: 60 * 60 },
+			{ start_time: s2, duration: 30 * 60 }
+		];
+
+		const localHour = new Date(s1).getHours();
+		// Assumption: s2 lands in same local hour (24h later usually does, unless DST shift)
+
+		const result = calculateHourlyDistribution(sessions as Session[], false); // auto divisor
+
+		// Total minutes: 90. Active days: 2.
+		// Avg: 45.
+		expect(result[localHour]).toBe(45);
+	});
+
+	it("should use divisor 1 when forceTotal is true", () => {
+		const s1 = "2024-01-01T10:00:00Z";
+		const s2 = "2024-01-02T10:00:00Z";
+
+		const sessions: Partial<Session>[] = [
+			{ start_time: s1, duration: 60 * 60 },
+			{ start_time: s2, duration: 30 * 60 }
+		];
+
+		const localHour = new Date(s1).getHours();
+
+		const result = calculateHourlyDistribution(sessions as Session[], true); // force total
+
+		// Total minutes: 90.
+		expect(result[localHour]).toBe(90);
+	});
+});

--- a/src/funcs/stats/productivity.ts
+++ b/src/funcs/stats/productivity.ts
@@ -1,0 +1,51 @@
+import type { Session } from "../commands";
+import { fromUTCString } from "./date_handling";
+
+export function calculateHourlyDistribution(
+	sessions: Session[],
+	forceTotal = false
+): number[] {
+	const hours = new Array(24).fill(0);
+	const uniqueDays = new Set<string>();
+
+	sessions.forEach((s) => {
+		if (!s.start_time || !s.duration) return;
+
+		const startDate = fromUTCString(s.start_time);
+
+		// Track active days for divisor (YYYY-MM-DD)
+		uniqueDays.add(startDate.toLocaleDateString());
+
+		let currentH = startDate.getHours();
+		let currentM = startDate.getMinutes();
+		let remainingDurationMinutes = s.duration / 60;
+
+		// Distribute duration across hour buckets
+		while (remainingDurationMinutes > 0) {
+			// Minutes left in the current hour bucket
+			// e.g. at 8:30, 30 mins left in hour 8
+			const minutesLeftInHour = 60 - currentM;
+
+			// Take whichever is smaller: remainder or available space
+			const contribution = Math.min(
+				remainingDurationMinutes,
+				minutesLeftInHour
+			);
+
+			// Add to bucket (handle 24h wrap-around)
+			hours[currentH % 24] += contribution;
+
+			// Update state
+			remainingDurationMinutes -= contribution;
+			currentH++;
+			currentM = 0; // Next hour starts at :00
+		}
+	});
+
+	// Divisor logic:
+	// If forceTotal (e.g. 1D view), we show totals (divisor 1).
+	// Otherwise, we show Average Daily Productivity *on active days*.
+	const divisor = forceTotal ? 1 : Math.max(1, uniqueDays.size);
+
+	return hours.map((h) => Math.round(h / divisor));
+}


### PR DESCRIPTION
Change:
 - Dev seed data now only fills possible times (e.g no two overlapping sessions)

New feature:
 - Charts timeframe can be selected to be 1D, 1M, 1Y or YTD.
 - E2E and unit tests added